### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/KrlSbin/railtrack/security/code-scanning/1](https://github.com/KrlSbin/railtrack/security/code-scanning/1)

To fix this issue, add a `permissions` block to the workflow or to the affected job(s), specifying least privilege. In this workflow, most steps do not require write access to repository contents—checkout only needs `contents: read`—and uploading artifacts does not need repo write. Therefore, a minimal `permissions` block of `contents: read` is suitable, placed either at the workflow root (applies to all jobs) or directly under the `scan_lint_test` job. If later a job requires more permissions (e.g., writing issues or PRs), those can be added as needed.

**Detailed fix for current code:**  
- Insert a root-level `permissions` block below the workflow name (recommended for single-job workflows).
- Set `contents: read` as the minimal starting point.
- No existing functionality will change, as no steps require greater permission.

Change to be made within file `.github/workflows/ci.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
